### PR TITLE
add unordered_map to headers

### DIFF
--- a/source/frontends/mariani/cadirectsound.cpp
+++ b/source/frontends/mariani/cadirectsound.cpp
@@ -6,6 +6,7 @@
 //  Forked from frontends/sdl/sdirectsound.cpp
 //
 
+#include <unordered_map>
 #include <AudioToolbox/AudioToolbox.h>
 #include "windows.h"
 #include "Core.h"


### PR DESCRIPTION
unordered_map has to be included explicitly with (at least some versions of) Clang